### PR TITLE
Constraint getStatus and Solver limitTime_ms

### DIFF
--- a/src/main/java/org/chocosolver/capi/ConstraintApi.java
+++ b/src/main/java/org/chocosolver/capi/ConstraintApi.java
@@ -2234,4 +2234,18 @@ public class ConstraintApi {
         }
         return 2;
     }
+
+    @CEntryPoint(name = Constants.METHOD_PREFIX + API_PREFIX + "getStatus")
+    public static int getStatus(IsolateThread thread, ObjectHandle constraintHandle) {
+        Constraint constraint = globalHandles.get(constraintHandle);
+        switch (constraint.getStatus()) {
+            case FREE:
+                return 0;
+            case POSTED:
+                return 1;
+            case REIFIED:
+                return 2;
+        }
+        return 3; // To detect invalid values
+    }
 }

--- a/src/main/java/org/chocosolver/capi/SolverApi.java
+++ b/src/main/java/org/chocosolver/capi/SolverApi.java
@@ -110,6 +110,12 @@ public class SolverApi {
         solver.limitTime(timeLimit);
     }
 
+    @CEntryPoint(name = Constants.METHOD_PREFIX + API_PREFIX + "limit_time_ms")
+    public static void limitTime_ms(IsolateThread thread, ObjectHandle solverHandler, long limit) {
+        Solver solver = globalHandles.get(solverHandler);
+        solver.limitTime(limit);
+    }
+
     @CEntryPoint(name = Constants.METHOD_PREFIX + API_PREFIX + "propagate")
     public static boolean propagate(IsolateThread thread, ObjectHandle solverHandler) {
         Solver solver = globalHandles.get(solverHandler);


### PR DESCRIPTION
During the development of Rust wrapper for our code realized that we need the following two functions

- get the status of constraint `public static int getStatus(IsolateThread thread, ObjectHandle constraintHandle)`
- limit solving time. `public static void limitTime_ms(IsolateThread thread, ObjectHandle solverHandler, long limit)`